### PR TITLE
Ready

### DIFF
--- a/1_concepts/1_1_default_clone_copy/src/main.rs
+++ b/1_concepts/1_1_default_clone_copy/src/main.rs
@@ -1,3 +1,22 @@
+#[derive(Default, Copy, Clone, Debug)]
+struct Point {
+    x: i32,
+    y: i32
+}
+
+
+#[derive(Clone, Debug)]
+struct Polyline {
+    points: Vec<Point>,
+}
+
+
+
 fn main() {
-    println!("Implement me!");
+    let p1 = Point::default();
+    let p2 = Point::default();
+    let p3 = Point {x : 10, y :11};
+    let pl = Polyline { points : vec![p1,p2,p3]};
+    let clone = pl.clone();
+    println!("p1:{:?},\n p2:{:?},\n p3:{:?},\n pl:{:?},\n clone:{:?}", p1, p2, p3, pl, clone);
 }

--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -1,3 +1,113 @@
+use std::fmt;
+use std::pin::Pin;
+use std::fmt::Debug;
+use std::rc::*;
+
+trait MutMeSomehow {
+    fn mut_me_somehow(self: Pin<&mut Self>);
+}
+
+trait SayHi: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+//Box<T>, Rc<T>, Vec<T>, String, &[u8], T
+#[derive(Debug)]
+struct MyMutable {
+    pub field: i32
+}
+impl Unpin for MyMutable {
+    // add code here
+}
+
+
+impl<T> SayHi for Box<T>
+    where T: Debug {}
+
+impl<T> SayHi for Rc<T>
+    where T: Debug {}
+
+impl<T> SayHi for Vec<T>
+    where T: Debug {}
+
+impl SayHi for String {}
+
+impl SayHi for &[u8] {}
+
+impl<T> MutMeSomehow for Box<T>
+    where T: Unpin + Default {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let x = self.get_mut().as_mut();
+        (*x) = T::default();
+    }
+}
+
+impl<T> MutMeSomehow for Rc<T>
+    where T: Unpin + Default {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let mut rc = self.get_mut();
+        let val = std::rc::Rc::<T>::get_mut(&mut rc)
+            .unwrap();
+        (*val) = T::default();
+    }
+}
+
+impl<T> MutMeSomehow for Vec<T>
+    where T: Unpin {
+    fn mut_me_somehow(self: Pin<&mut Self>){
+        let v = self.get_mut();
+        if v.len()>0 {
+           v.pop();
+        }
+    }
+}
+
+impl MutMeSomehow for String {
+    fn mut_me_somehow(self: Pin<&mut Self>){
+        let text = self.get_mut();
+        text.push_str("aaaaa");
+    }
+}
+//TODO Uncomment
+
+impl SayHi for MyMutable {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self);
+    }
+}
+
+impl MutMeSomehow for MyMutable {
+   fn mut_me_somehow(self: Pin<&mut Self>) {
+        let my_mut = self.get_mut();
+        my_mut.field = 100;
+    }
+ }
+
 fn main() {
-    println!("Implement me!");
+    //Box
+    let mut bx = std::boxed::Box::<i32>::new(12);
+    MutMeSomehow::mut_me_somehow(Pin::new(&mut bx));
+    SayHi::say_hi(Pin::new(&bx));
+
+    //rc
+    let mut rc = Rc::<i32>::new(10);
+    MutMeSomehow::mut_me_somehow(Pin::new(&mut rc));
+    SayHi::say_hi(Pin::new(&rc));
+
+    //Vec
+    let mut v = vec![10,20,30];
+    MutMeSomehow::mut_me_somehow(Pin::new(&mut v));
+    SayHi::say_hi(Pin::new(&v));
+
+    //String
+    let mut s = String::from("my string");
+    MutMeSomehow::mut_me_somehow(Pin::new(&mut s));
+    SayHi::say_hi(Pin::new(&s));
+
+    //MyMutable
+    let mut mm  = MyMutable{field:12};
+    MutMeSomehow::mut_me_somehow(Pin::new(&mut mm));
+    SayHi::say_hi(Pin::new(&mm))
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Each step has estimated time for being completed. If any deeper investigation on
 
 Do not hesitate to ask your lead with questions, however you won't receive a concrete answer, but rather a direction for investigation. _Lead is the one who asks questions about everything here and demands a concrete answers_.
 
-- [ ] [0. Become familiar with Rust basics][Step 0] (3 days)
+- [x] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days)
     - [ ] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
     - [ ] [1.2. Boxing and pinning][Step 1.2] (1 day)

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Do not hesitate to ask your lead with questions, however you won't receive a con
 
 - [x] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days)
-    - [ ] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
-    - [ ] [1.2. Boxing and pinning][Step 1.2] (1 day)
+    - [x] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
+    - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
     - [ ] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
     - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)


### PR DESCRIPTION
Task 0

Task 1_1
Step 1.1: Default values, cloning and copying
=============================================

__Estimated time__: 1 day




## Default values

[Rust] has a standard way to deal with default values of a type via [`Default`] trait. Read through [its official docs][`Default`] to understand the design.

It can be auto-derived, but only for a `struct` whose all members have [`Default`] implementations. It is implemented for a great many types in the standard library, and also used in a surprising number of places. So if your type has a value that can be construed as being "default", it is a good idea to implement this trait.

If you're not enough with [std] deriving capabilities for [`Default`], consider to use [smart-default] crate. An example is quite self-explanatory:
```rust
#[derive(SmartDefault)]
enum Foo {
    Bar,
    #[default]
    Baz {
        #[default = 12]
        a: i32,
        b: i32,
        #[default(Some(Default::default()))]
        c: Option<i32>,
        #[default(_code = "vec![1, 2, 3]")]
        d: Vec<u32>,
        #[default = "four"]
        e: String,
    },
    Qux(i32),
}
```

A great thing that having a [`Default`] implementation you can instantiate your `struct` with only the non-default values and have all other fields filled with default values:
```rust
let x = Foo { bar: baz, ..Default::default() };
```




## Cloning and copying

By default, all types in [Rust] follow ['move semantics'][1].

If you need a duplicate of a value, then its type should implement [`Clone`] trait (see [official docs][`Clone`]), and a duplicate is created by calling [`Clone`] methods __explicitly__. Cloning can be __either cheap or expensive__ operation depending on type semantics.

However, [`Copy`] marker trait (see [official docs][`Copy`]) enables 'copy semantics' for a type, so a value is __copied implicitly__ every time is passed. That's why copying must always perform a __simple bit-to-bit copy operation__.

[Official `Copy` docs][`Copy`] are quite explanatory about which types _should_ be [`Copy`] and which types _cannot_:

> Some types can't be copied safely. For example, copying `&mut T` would create an aliased mutable reference. Copying `String` would duplicate responsibility for managing the `String`'s buffer, leading to a double free.
> 
> Generalizing the latter case, any type implementing `Drop` can't be `Copy`, because it's managing some resource besides its own `size_of::<T>` bytes.

> Generally speaking, if your type can implement `Copy`, it should. Keep in mind, though, that implementing `Copy` is part of the public API of your type. If the type might become non-`Copy` in the future, it could be prudent to omit the `Copy` implementation now, to avoid a breaking API change.




## Task

- Create a `Point` type which represents a 2D point (`x` and `y` coordinates). This type has to be `Copy` and `Default`.
- Create a `Polyline` type which represents a non-empty set of `Point`s of unknown size. This type has to be `Clone` and non-`Default`. 





[`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
[`Copy`]: https://doc.rust-lang.org/std/marker/trait.Copy.html
[`Default`]: https://doc.rust-lang.org/std/default/trait.Default.html
[std]: https://doc.rust-lang.org/stable/std
[smart-default]: https://docs.rs/smart-default
[Rust]: https://www.rust-lang.org

[1]: https://stackoverflow.com/a/30290070/1828012

