### PR TITLE
1 4

### DIFF
--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -43,6 +43,7 @@ impl<T> MutMeSomehow for Box<T>
         (*x) = T::default();
     }
 }
+ 
 
 impl<T> MutMeSomehow for Rc<T>
     where T: Unpin + Default {

--- a/1_concepts/1_3_rc_cell/src/main.rs
+++ b/1_concepts/1_3_rc_cell/src/main.rs
@@ -1,3 +1,59 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+struct GlobalStack<T>(Arc<Mutex<Vec<T>>>);
+
+impl<T> GlobalStack<T> {
+    pub fn new() -> Self {
+        GlobalStack { 0: Arc::new(Mutex::new(vec![])) }
+    }
+
+    pub fn push(&self, item:T) {
+        let mut mutex = self.0.lock().unwrap();
+        (*mutex).push(item);
+    }
+    pub fn pop(&self) -> Option<T> {
+        let mut mutex = self.0.lock().unwrap();
+        (*mutex).pop()
+    }
+    pub fn len(&self) -> usize {
+        (*self.0.lock().unwrap()).len()
+    }
+}
+
+impl<T> Clone for GlobalStack<T> {
+    fn clone(&self) -> Self {
+        GlobalStack{0: self.0.clone() }
+    }
+}
+
 fn main() {
-    println!("Implement me!");
+    let gstack : GlobalStack<i32> = GlobalStack::<i32>::new();
+    let t1_gstack = gstack.clone();
+    let t2_gstack = gstack.clone();
+    let thread1 = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        &t1_gstack.push(100);
+        println!("t1: {}",&t1_gstack.len());
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        &t1_gstack.push(101);
+        println!("t1: {}",&t1_gstack.len());
+    });
+    let thread2 = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        &t2_gstack.push(200);
+        println!("t2: {}",&t2_gstack.len());
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        &t2_gstack.push(201);
+        println!("t2: {}",&t2_gstack.len());
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        &t2_gstack.push(202);
+        println!("t2: {}",&t2_gstack.len());
+    });
+    thread1.join().unwrap();
+    thread2.join().unwrap();
+    println!("{:?}",gstack);
+    gstack.pop();
+    println!("{:?}",gstack);
+    
 }

--- a/1_concepts/1_4_cow/Cargo.toml
+++ b/1_concepts/1_4_cow/Cargo.toml
@@ -3,3 +3,6 @@ name = "1_4"
 version = "0.1.0"
 edition = "2018"
 publish = false
+
+[dependencies]
+clap = "2.33.0"

--- a/1_concepts/1_4_cow/src/main.rs
+++ b/1_concepts/1_4_cow/src/main.rs
@@ -1,3 +1,33 @@
+extern crate clap;
+
+use clap::{Arg, App};
+
+use std::borrow::{Cow};
+
 fn main() {
-    println!("Implement me!");
+    let matches = App::new("Nan")
+        .version("1.0")
+        .arg(Arg::with_name("conf")
+            .long("conf")
+            .value_name("FILE")
+            .help("Sets a custom config file")
+            .takes_value(true))
+        .get_matches();
+
+    let p = String::from("/etc/app/app.conf");
+    let mut cow = Cow::from(p);
+    let env_var = std::env::var("APP_CONF");
+    match env_var {
+        Ok(conf) => {
+            let mut_cow = cow.to_mut();
+            *mut_cow = conf;
+        }
+        Err(_) => { }
+    }
+    if matches.is_present("conf") {
+        let cow_mut = cow.to_mut();
+        *cow_mut = matches.value_of("conf").unwrap().to_owned();
+    }
+    println!("{}", cow.to_owned());
+
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Do not hesitate to ask your lead with questions, however you won't receive a con
     - [x] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
     - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
     - [x] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
-    - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
+    - [x] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
     - [ ] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)
     - [ ] [1.7. `Sized` and `?Sized` types][Step 1.7] (1 day)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Do not hesitate to ask your lead with questions, however you won't receive a con
 - [ ] [1. Concepts][Step 1] (2 days)
     - [x] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
     - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
-    - [ ] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
+    - [x] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
     - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
     - [ ] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)


### PR DESCRIPTION
---
Step 1.4
---
Step 1.4: Clone-on-write
========================

__Estimated time__: 1 day




## Clone-on-write

[Rust] has a [`Cow`] (clone-on-write) smart pointer in its standard library. Understanding how to use it is _essential to write idiomatic and ergonomic_ [Rust] code.

In a nutshell: 
- it allows to combine usage of owned and borrowed data in a single abstraction, which __leads to better ergonomics and minimize performance penalties asap__ (as much as possible);
- it encloses and provides immutable access to borrowed data, and __clones the data lazily when mutation or ownership is required__.

```rust
use std::borrow::Cow;

fn describe(error: &Error) -> Cow<'static, str> {
    match *error {
        // Returning &'str - a borrowed reference to static str.
        Error::NotFound => "Error: Not found".into(),
        
        // Returning String - an owned String allocated in heap.
        Error::Custom(e) => format!("Error: {}", e).into(),
    }
}
```

For better understanding [`Cow`] purpose, design, limitations and use cases read through:
- [Pascal Hertleif: The Secret Life of Cows][1]
- [Official `Cow` docs][`Cow`]




## Task

Write a simple program which prints out the path to its configuration file. The path should be detected with the following precedence:
1. default path is `/etc/app/app.conf`;
2. if `APP_CONF` env var is specified (and not empty) then use it;
3. if `--conf` command line argument is specified (error if empty) then use it.

If neither `APP_CONF` env var nor `--conf` command line argument is specified, then no allocation should happen for path detection.





[`Cow`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
[Rust]: https://www.rust-lang.org

[1]: https://deterministic.space/secret-life-of-cows.html
